### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://guotiandancloud.visualstudio.com/169e2ba2-e5c7-4b69-a29b-c8970fd997bb/364c6307-6a16-4539-8e2c-1d6ff13a8f98/_apis/work/boardbadge/e2922730-22e6-4938-945d-c6b5b6ca0db8)](https://guotiandancloud.visualstudio.com/169e2ba2-e5c7-4b69-a29b-c8970fd997bb/_boards/board/t/364c6307-6a16-4539-8e2c-1d6ff13a8f98/Microsoft.RequirementCategory)
 - 👋 Hi, I’m @Gtiandan
 - 👀 I’m interested in software crowdsourcing
 - 🌱 I’m currently learning phyth


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://guotiandancloud.visualstudio.com/169e2ba2-e5c7-4b69-a29b-c8970fd997bb/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.